### PR TITLE
Bump common dependency from 0.4.0 to 0.4.3 in Glance chart

### DIFF
--- a/charts/glance/Chart.lock
+++ b/charts/glance/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://rubxkube.github.io/common-charts
-  version: v0.4.0
-digest: sha256:1446dc232489a62e6d2775c2f3917bd7c816c2f9a4a18e67ed323aa75f3c0ea2
-generated: "2024-12-23T17:32:51.086604+01:00"
+  version: v0.4.3
+digest: sha256:b8a2c40d63e583c76e0725df8bb7587a7e20ca30c03a9d98dafe10aa643b79d0
+generated: "2025-05-03T13:22:59.772440769+02:00"

--- a/charts/glance/Chart.yaml
+++ b/charts/glance/Chart.yaml
@@ -20,4 +20,4 @@ sources:
 dependencies:
   - name: common
     repository: https://rubxkube.github.io/common-charts
-    version: v0.4.0
+    version: v0.4.3

--- a/charts/glance/Chart.yaml
+++ b/charts/glance/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 type: application
 name: glance
 description: A self-hosted dashboard that puts all your feeds in one place
-version: 0.0.4
+version: 0.0.5
 appVersion: v0.6.4
 maintainers:
   - name: QJOLY


### PR DESCRIPTION
## Chart Addition Pull Request

Name: Glance
version: 0.0.5
tests:

**Additional Information**

Makes the use of existingConfigMap possible

**Checklist**

Please review and check the following before submitting this pull request:

- [x] I have tested the chart locally and it works as expected.
- ~[] I have included a valid `Chart.yaml` file with the required information.~
- ~[ ] I have documented the usage and configuration options of the chart in the README.md file.~
- ~[ ] I have included any necessary dependencies and mentioned them in the README.md file.~
- ~[ ] I have considered security best practices while creating the chart.~

**Screenshots or Examples (if applicable)**

N/A

**Related Issues**

Closes #289

**Reviewers**
@qjoly (I guess ?)
