### PR TITLE
Fix kyoo ingress

### DIFF
--- a/charts/kyoo/templates/ingress.yaml
+++ b/charts/kyoo/templates/ingress.yaml
@@ -5,10 +5,10 @@ metadata:
   name: {{ .Release.Name }}
   labels:
     app: {{ .Release.Name }}
-{{- if .Values.ingress.annotations }}
+  {{- with .Values.ingress.annotations }}
   annotations:
-  {{ toYaml .Values.ingress.annotations | indent 4 }}
-{{- end }}
+{{ toYaml . | indent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName }}


### PR DESCRIPTION
The following values were not working:

```yaml
ingress:
  enabled: true
  hostName: "kyoo.une-tasse-de.cafe"
  ingressClassName: "traefik"
  extraLabels: {}
  annotations:
    cert-manager.io/cluster-issuer: cloudflare
    external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
    external-dns.alpha.kubernetes.io/hostname: kyoo.une-tasse-de.cafe
```
