### PR TITLE
fix(joplin): move POSTGRES_PASSWORD to secret.data to support external secret

### DIFF
--- a/charts/joplin/Chart.yaml
+++ b/charts/joplin/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 name: joplin
 description: Joplin is an open source note-taking app. Capture your thoughts and securely access them from any device.
-version: 1.2.1
+version: 1.2.2
 appVersion: "3.0-beta"
 icon: https://raw.githubusercontent.com/RubxKube/charts/main/img/joplin-logo.png
 keywords:

--- a/charts/joplin/values.yaml
+++ b/charts/joplin/values.yaml
@@ -63,12 +63,20 @@ common:
 
   # env variables
   variables:
-    secret: {}
+    secret:
+      data:
+        POSTGRES_PASSWORD: "joplinpass"
+      # To use an existing secret for POSTGRES_PASSWORD (e.g. when postgresql.enabled=false):
+      #   set data: ~ to remove the default, then reference your secret:
+      # data: ~
+      # existingSecret:
+      #   - name: my-pg-secret
+      #     key: password
+      #     envName: POSTGRES_PASSWORD
     nonSecret:
       DB_CLIENT: pg
       POSTGRES_DATABASE: "joplin"
       POSTGRES_USER: "joplinuser"
-      POSTGRES_PASSWORD: "joplinpass"
       POSTGRES_HOST: "joplin-postgresql" # if postgresql.enabled, must be RELEASE-NAME-postgresql (ex: my-wakapi-postgresql)
       POSTGRES_PORT: "5432"
       APP_BASE_URL: https://joplin.une-tasse-de.cafe


### PR DESCRIPTION

Fixes #331 — POSTGRES_PASSWORD was hardcoded in nonSecret as plain text, making it impossible to replace with a K8s secretKeyRef. Moving it to secret.data stores it in a proper K8s Secret and allows users to override it or substitute their own existing secret via existingSecret.

