### PR TITLE
chore: upgrade postgresql dependency to 18.x

### DIFF
--- a/charts/joplin/Chart.lock
+++ b/charts/joplin/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: v0.4.5
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 16.2.5
-digest: sha256:f232c0c1b62289375862baeb81b7935b7dcd11c0b18d8327d64d9a93509d559f
-generated: "2025-05-31T09:45:33.454566224Z"
+  version: 18.5.24
+digest: sha256:c7025780de092a83c20612d09c74001c398972905c25cf72fb494d3d1bcd1606
+generated: "2026-04-18T18:08:21.090228865-05:00"

--- a/charts/joplin/Chart.yaml
+++ b/charts/joplin/Chart.yaml
@@ -1,25 +1,26 @@
 ---
 apiVersion: v2
 name: joplin
-description: Joplin is an open source note-taking app. Capture your thoughts and securely access them from any device.
+description: Joplin is an open source note-taking app. Capture your thoughts and
+  securely access them from any device.
 version: 1.2.2
 appVersion: "3.0-beta"
 icon: https://raw.githubusercontent.com/RubxKube/charts/main/img/joplin-logo.png
 keywords:
- - joplin
+  - joplin
 home: https://joplinapp.org/
 maintainers:
- - email: github@une-tasse-de.cafe
-   name: QJOLY
-   url: https://une-tasse-de.cafe
+  - email: github@une-tasse-de.cafe
+    name: QJOLY
+    url: https://une-tasse-de.cafe
 sources:
- - https://github.com/laurent22/joplin
- - https://github.com/QJoly/helm-charts
+  - https://github.com/laurent22/joplin
+  - https://github.com/QJoly/helm-charts
 dependencies:
- - name: common
-   repository: https://rubxkube.github.io/common-charts
-   version: v0.4.5
- - name: postgresql
-   version: 16.2.5
-   repository: https://charts.bitnami.com/bitnami
-   condition: postgresql.enabled
+  - name: common
+    repository: https://rubxkube.github.io/common-charts
+    version: v0.4.5
+  - name: postgresql
+    version: "18.x"
+    repository: https://charts.bitnami.com/bitnami
+    condition: postgresql.enabled


### PR DESCRIPTION
fix for #371 

Bitnami removed all of the old versions of the images from the docker registry, leaving only newer versions.

Updated to a newer version of postgresql and verified it's pulling images. 