### PR TITLE
chore: upgrade uptime-kuma to 2.2.1 and update common library dependency to 0.5.0

### DIFF
--- a/charts/uptime-kuma/Chart.lock
+++ b/charts/uptime-kuma/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://rubxkube.github.io/common-charts
-  version: v0.4.5
-digest: sha256:c95faac6400a645e46baf667308836a3256560d08778b2fd4393fbeef394e011
-generated: "2025-05-31T10:10:09.506306064Z"
+  version: v0.5.0
+digest: sha256:c5c89d76d19f76b0a8f6402edc4b0baea3336e8bbb89f69a23dad3818b113e93
+generated: "2026-04-17T18:37:22.789917665-05:00"

--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 type: application
 name: uptime-kuma
 description: Uptime Kuma is an easy-to-use self-hosted monitoring tool.
-version: 1.1.18
-appVersion: 1.23.15
+version: 1.1.19
+appVersion: 2.2.1
 icon: https://raw.githubusercontent.com/RubxKube/charts/main/img/uptime-kuma-logo.png
 maintainers:
   - name: QJOLY
@@ -20,4 +20,4 @@ sources:
 dependencies:
   - name: common
     repository: https://rubxkube.github.io/common-charts
-    version: v0.4.5
+    version: v0.5.0

--- a/charts/uptime-kuma/README.md
+++ b/charts/uptime-kuma/README.md
@@ -45,7 +45,7 @@ Kubernetes: `>= 1.18`
 | common.image.repository | string | `"louislam/uptime-kuma"` |  |
 | common.image.repositorySettings.isPrivate | bool | `false` |  |
 | common.image.repositorySettings.secretName | string | `nil` |  |
-| common.image.tag | string | `"1.23.11"` |  |
+| common.image.tag | string | `"2.2.1"` |  |
 | common.ingress.certResolver | string | `"letsencrypt"` |  |
 | common.ingress.enabled | bool | `false` |  |
 | common.ingress.entrypoint | string | `"websecure"` |  |

--- a/charts/uptime-kuma/values.yaml
+++ b/charts/uptime-kuma/values.yaml
@@ -29,8 +29,8 @@ common:
     repositorySettings:
       isPrivate: false
       secretName: null
-    repository: elestio/uptime-kuma
-    tag: 1.23.15
+    repository: louislam/uptime-kuma
+    tag: 2.2.1
     pullPolicy: Always
 
   # ingress


### PR DESCRIPTION
## Chart Update Pull Request

Name: uptime-kuma
version: 1.1.19

**Additional Information**

Changed docker container to louislam/uptime-kuma instead of elastio/uptime-kuma. Personal preference, but I've always used the louislam distrobution. 

**Checklist**

Please review and check the following before submitting this pull request:

- [x] I have tested the chart locally and it works as expected.
- [x] I have considered security best practices while creating the chart.

**Version Information**

- [x] I have updated the min version in the Chart.yaml file if necessary.
- [ ] I want a new patch version for this chart (I don't need to update the min version in the Chart.yaml file).