### PR TITLE
fix: make kyoo deploy cleanly

### DIFF
--- a/charts/joplin/Chart.lock
+++ b/charts/joplin/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: v0.4.5
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 16.2.5
-digest: sha256:f232c0c1b62289375862baeb81b7935b7dcd11c0b18d8327d64d9a93509d559f
-generated: "2025-05-31T09:45:33.454566224Z"
+  version: 18.6.8
+digest: sha256:fad125f082908080ef9da44c56c27aceb53381674b1ec6c5d9c4089ec24514f9
+generated: "2026-05-28T11:55:37.590584484Z"

--- a/charts/joplin/Chart.yaml
+++ b/charts/joplin/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 name: joplin
 description: Joplin is an open source note-taking app. Capture your thoughts and securely access them from any device.
-version: 1.2.1
+version: 2.0.0
 appVersion: "3.0-beta"
 icon: https://raw.githubusercontent.com/RubxKube/charts/main/img/joplin-logo.png
 keywords:
@@ -20,6 +20,6 @@ dependencies:
    repository: https://rubxkube.github.io/common-charts
    version: v0.4.5
  - name: postgresql
-   version: 16.2.5
+   version: 18.6.8
    repository: https://charts.bitnami.com/bitnami
    condition: postgresql.enabled

--- a/charts/kyoo/Chart.lock
+++ b/charts/kyoo/Chart.lock
@@ -22,9 +22,9 @@ dependencies:
   version: 0.10.2
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 16.2.5
+  version: 18.6.8
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
   version: 16.0.14
-digest: sha256:2dff8cd03cd4b3da61688db80c6522eee5d53e2dec596d373779de512f99db6b
-generated: "2026-03-13T10:44:27.932302315Z"
+digest: sha256:53254758896776b9c154c40f2bf721776f43511aeedf4913011d938b31863c45
+generated: "2026-05-28T11:56:15.754626053Z"

--- a/charts/kyoo/Chart.yaml
+++ b/charts/kyoo/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 name: kyoo
 description: Kyoo is a media manager and transcoder for your media files.
 # Patch version are managed by a workflow
-version: 0.1
+version: "0.1"
 appVersion: "4.7.0"
 icon: https://github.com/zoriya/Kyoo/blob/master/icons/icon-256x256.png?raw=true
 # Maintainer of the Chart

--- a/charts/kyoo/Chart.yaml
+++ b/charts/kyoo/Chart.yaml
@@ -57,7 +57,7 @@ dependencies:
   - condition: postgresql.enabled
     name: postgresql
     repository: https://charts.bitnami.com/bitnami
-    version: 16.2.5
+    version: 18.6.8
   - condition: rabbitmq.enabled
     name: rabbitmq
     repository: https://charts.bitnami.com/bitnami

--- a/charts/kyoo/values.yaml
+++ b/charts/kyoo/values.yaml
@@ -26,6 +26,7 @@ front:
   name: "front"
   enabled: true
   deployment:
+    cpuRequest: "100m"
     port: 8901
     cpuLimit: "250m"
     memoryLimit: "100Mi"
@@ -48,6 +49,7 @@ back:
   name: "back"
   enabled: true
   deployment:
+    cpuRequest: "250m"
     cpuLimit: "1000m"
     # 2Gi is the minimum recommended for the back
     memoryLimit: "2000Mi"
@@ -129,6 +131,7 @@ transcoder:
   name: "transcoder"
   enabled: true
   deployment:
+    cpuRequest: "250m"
     cpuLimit: "1000m"
     memoryLimit: "500Mi"
     port: 7666
@@ -195,6 +198,7 @@ scanner:
   name: "scanner"
   enabled: true
   deployment:
+    cpuRequest: "100m"
     cpuLimit: "250m"
     memoryLimit: "300Mi"
   image:
@@ -241,6 +245,7 @@ scanner:
 autosync:
   enabled: true
   name: "autosync"
+  cpuRequest: "100m"
   cpuLimit: "250m"
   memoryLimit: "300Mi"
   image:
@@ -264,6 +269,7 @@ matcher:
   enabled: true
   name: "matcher"
   deployment:
+    cpuRequest: "100m"
     cpuLimit: "500m"
     memoryLimit: "300Mi"
     args:
@@ -371,6 +377,9 @@ secrets:
 
 rabbitmq:
   enabled: true
+  fullnameOverride: kyoo-rabbitmq
+  image:
+    repository: bitnamilegacy/rabbitmq
   auth:
     # Sadly, the rabbitmq chart does not support existing secrets for the user
     # By default, the user is the one generated in .rabbitmq.secrets.rabbitmq.data.rabbitmq_user
@@ -382,6 +391,7 @@ rabbitmq:
 
 postgresql:
   enabled: true
+  fullnameOverride: kyoo-postgresql
   auth:
     username: kyoouserherefordb
   back:
@@ -412,6 +422,7 @@ postgresql:
 
 meilisearch:
   enabled: true
+  fullnameOverride: kyoo-meilisearch
   environment:
     MEILI_ENV: production
   auth:


### PR DESCRIPTION
Follow-up to #367.

This PR carries the Kyoo chart fixes needed alongside the PostgreSQL v18 update.

Included fixes:
- quote chart version so `helm lint` passes
- align dependency service names with app expectations via `fullnameOverride`
- lower default CPU requests so the chart schedules with its existing defaults
- use the working RabbitMQ image repository override

Validation performed:
- `helm dependency build`
- `helm lint`
- `helm upgrade --install --wait`
- `helm test`