### PR TITLE
fix: keep joplin postgresql service name stable

### DIFF
--- a/charts/joplin/Chart.lock
+++ b/charts/joplin/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: v0.4.5
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 16.2.5
-digest: sha256:f232c0c1b62289375862baeb81b7935b7dcd11c0b18d8327d64d9a93509d559f
-generated: "2025-05-31T09:45:33.454566224Z"
+  version: 18.6.8
+digest: sha256:fad125f082908080ef9da44c56c27aceb53381674b1ec6c5d9c4089ec24514f9
+generated: "2026-05-28T11:55:37.590584484Z"

--- a/charts/joplin/Chart.yaml
+++ b/charts/joplin/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 name: joplin
 description: Joplin is an open source note-taking app. Capture your thoughts and securely access them from any device.
-version: 1.2.1
+version: 2.0.0
 appVersion: "3.0-beta"
 icon: https://raw.githubusercontent.com/RubxKube/charts/main/img/joplin-logo.png
 keywords:
@@ -20,6 +20,6 @@ dependencies:
    repository: https://rubxkube.github.io/common-charts
    version: v0.4.5
  - name: postgresql
-   version: 16.2.5
+   version: 18.6.8
    repository: https://charts.bitnami.com/bitnami
    condition: postgresql.enabled

--- a/charts/joplin/values.yaml
+++ b/charts/joplin/values.yaml
@@ -3,6 +3,8 @@ define: &containerPort 22300
 
 postgresql:
   enabled: true
+  # Keep the generated service name aligned with the app's fixed DB host setting.
+  fullnameOverride: "joplin-postgresql"
   auth:
     postgresPassword: "changeme"
     database: joplin

--- a/charts/kyoo/Chart.lock
+++ b/charts/kyoo/Chart.lock
@@ -22,9 +22,9 @@ dependencies:
   version: 0.10.2
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 16.2.5
+  version: 18.6.8
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
   version: 16.0.14
-digest: sha256:2dff8cd03cd4b3da61688db80c6522eee5d53e2dec596d373779de512f99db6b
-generated: "2026-03-13T10:44:27.932302315Z"
+digest: sha256:53254758896776b9c154c40f2bf721776f43511aeedf4913011d938b31863c45
+generated: "2026-05-28T11:56:15.754626053Z"

--- a/charts/kyoo/Chart.yaml
+++ b/charts/kyoo/Chart.yaml
@@ -57,7 +57,7 @@ dependencies:
   - condition: postgresql.enabled
     name: postgresql
     repository: https://charts.bitnami.com/bitnami
-    version: 16.2.5
+    version: 18.6.8
   - condition: rabbitmq.enabled
     name: rabbitmq
     repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
Follow-up to #367.

This PR carries the Joplin chart fix needed alongside the PostgreSQL v18 update.

Included fix:
- pin PostgreSQL fullname so the app resolves its configured DB host

Validation performed:
- `helm dependency build`
- `helm lint`
- `helm upgrade --install --wait`
- `helm test`