### PR TITLE
fix(ci): release version bump produces invalid semver (X.Y.Z.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,9 @@ jobs:
               chart_minor=$(echo "$chart_version" | cut -d. -f2)
               if [[ "$actual_minor" != "$chart_minor" ]]; then
                 echo "INFO: Minor version difference between Chart.yaml ($chart_version) and latest tag ($actual_version)"
-                sed -i "s/^version:.*/version: $chart_version.0/" Chart.yaml
+                # Chart.yaml already holds the full target version (e.g. 0.1.0);
+                # use it verbatim. Appending ".0" produced invalid semver (0.1.0.0).
+                sed -i "s/^version:.*/version: $chart_version/" Chart.yaml
               else
                 new_version=$(echo "$actual_version" | awk -F. -v OFS=. '{$NF++; print}')
                 sed -i "s/^version:.*/version: $new_version/" Chart.yaml


### PR DESCRIPTION
## Problème

Le job `release` de `Release Charts` échoue au packaging :
```
Packaging chart 'charts/audiobookshelf'...
Error: validation: chart.metadata.version "0.1.0.0" is invalid
```

## Cause

Dans `release.yml`, quand le *minor* du Chart.yaml diffère du dernier tag, l'étape de bump faisait `version: $chart_version.0` — or `$chart_version` est déjà complet (ex: `0.1.0`), d'où `0.1.0.0` (semver invalide). Les bumps de minor de la PR #231 (audiobookshelf 0.1.0, joplin 1.3.0, memo 1.2.0, radarr 1.4.0…) tombent tous dans cette branche → chart-releaser plante sur le 1er chart → **aucune release publiée**.

## Fix

Utiliser la version du Chart.yaml telle quelle (elle représente déjà `X.Y.0`).

Une fois mergé, le push sur `main` relance `Release Charts` : l'étape de bump est sautée (aucun `charts/**` modifié ici) et `chart-releaser` publie les charts en attente à leur version correcte.

https://claude.ai/code/session_01MHWjtAcTE2TCP7wVTXoW4h