### PR TITLE
fix(audiobookshelf): bump to 0.1.1 (0.1.0 tag burned by immutable release)

### DIFF
--- a/charts/audiobookshelf/Chart.yaml
+++ b/charts/audiobookshelf/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 type: application
 name: audiobookshelf
 description: "Self-hosted audiobook and podcast server."
-version: 0.1.0
+version: 0.1.1
 appVersion: "v2.29.0"
 # icon:
 maintainers:


### PR DESCRIPTION
Le tag `audiobookshelf-0.1.0` a été consommé par une release immuable échouée ; GitHub réserve définitivement ce nom de tag (impossible à recréer même après suppression). Bump en `0.1.1` pour publier un tag neuf.

Une fois mergé, `Release Charts` publiera audiobookshelf-0.1.1 **et** tous les autres charts en attente (joplin-1.3.0, memo-1.2.0, radarr-1.4.0, etc.) dont les tags n'ont jamais été immuables.

https://claude.ai/code/session_01MHWjtAcTE2TCP7wVTXoW4h