### PR TITLE
feat(spindle): add spindle chart

### DIFF
--- a/charts/spindle/Chart.lock
+++ b/charts/spindle/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://rubxkube.github.io/common-charts
-  version: v0.6.0
-digest: sha256:31ca898a50222fc13a29732b99280568f236ed2e307579ca88b7ab9203de5088
-generated: "2026-08-11T17:45:55.054247+02:00"
+  version: v0.6.2
+digest: sha256:24e7d624710ad6c8e9cb8330e306abdf91178fc755d3409debdacace0a54506c
+generated: "2026-08-11T19:00:39.356536+02:00"

--- a/charts/spindle/Chart.lock
+++ b/charts/spindle/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: common
+  repository: https://rubxkube.github.io/common-charts
+  version: v0.6.0
+digest: sha256:31ca898a50222fc13a29732b99280568f236ed2e307579ca88b7ab9203de5088
+generated: "2026-08-11T17:45:55.054247+02:00"

--- a/charts/spindle/Chart.yaml
+++ b/charts/spindle/Chart.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: v2
+type: application
+name: spindle
+description: "Spindle is the self-hosted CI runner of Tangled, the git platform built on ATProto."
+version: 0.1.0
+appVersion: "v1.16.1-alpha"
+# icon:
+maintainers:
+  - name: QJOLY
+    email: github@une-tasse-de.cafe
+kubeVersion: ">= 1.18"
+home: https://docs.tangled.org/spindles
+keywords:
+  - spindle
+  - tangled
+  - ci
+  - atproto
+sources:
+  - https://tangled.org/tangled.org/core
+dependencies:
+  - name: common
+    repository: https://rubxkube.github.io/common-charts
+    version: v0.6.0

--- a/charts/spindle/Chart.yaml
+++ b/charts/spindle/Chart.yaml
@@ -21,4 +21,4 @@ sources:
 dependencies:
   - name: common
     repository: https://rubxkube.github.io/common-charts
-    version: v0.6.0
+    version: v0.6.2

--- a/charts/spindle/README.md
+++ b/charts/spindle/README.md
@@ -1,0 +1,116 @@
+# spindle
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.16.1-alpha](https://img.shields.io/badge/AppVersion-v1.16.1--alpha-informational?style=flat-square)
+
+Spindle is the self-hosted CI runner of Tangled, the git platform built on ATProto.
+
+**Homepage:** <https://docs.tangled.org/spindles>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| QJOLY | <github@une-tasse-de.cafe> |  |
+
+## Source Code
+
+* <https://tangled.org/tangled.org/core>
+
+## Requirements
+
+Kubernetes: `>= 1.18`
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://rubxkube.github.io/common-charts | common | v0.6.0 |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| common.deployment.additionalContainers[0].args[0] | string | `"dockerd"` |  |
+| common.deployment.additionalContainers[0].args[1] | string | `"--host=unix:///var/run/docker.sock"` |  |
+| common.deployment.additionalContainers[0].args[2] | string | `"--host=tcp://127.0.0.1:2375"` |  |
+| common.deployment.additionalContainers[0].args[3] | string | `"--tls=false"` |  |
+| common.deployment.additionalContainers[0].env[0].name | string | `"DOCKER_TLS_CERTDIR"` |  |
+| common.deployment.additionalContainers[0].env[0].value | string | `""` |  |
+| common.deployment.additionalContainers[0].image | string | `"docker:29.7.2-dind"` |  |
+| common.deployment.additionalContainers[0].imagePullPolicy | string | `"IfNotPresent"` |  |
+| common.deployment.additionalContainers[0].name | string | `"dind"` |  |
+| common.deployment.additionalContainers[0].readinessProbe.exec.command[0] | string | `"docker"` |  |
+| common.deployment.additionalContainers[0].readinessProbe.exec.command[1] | string | `"-H"` |  |
+| common.deployment.additionalContainers[0].readinessProbe.exec.command[2] | string | `"tcp://127.0.0.1:2375"` |  |
+| common.deployment.additionalContainers[0].readinessProbe.exec.command[3] | string | `"info"` |  |
+| common.deployment.additionalContainers[0].readinessProbe.initialDelaySeconds | int | `10` |  |
+| common.deployment.additionalContainers[0].readinessProbe.periodSeconds | int | `15` |  |
+| common.deployment.additionalContainers[0].resources.limits.memory | string | `"10Gi"` |  |
+| common.deployment.additionalContainers[0].resources.requests.cpu | string | `"100m"` |  |
+| common.deployment.additionalContainers[0].resources.requests.memory | string | `"512Mi"` |  |
+| common.deployment.additionalContainers[0].securityContext.privileged | bool | `true` |  |
+| common.deployment.additionalContainers[0].volumeMounts[0].mountPath | string | `"/var/lib/docker"` |  |
+| common.deployment.additionalContainers[0].volumeMounts[0].name | string | `"docker-data"` |  |
+| common.deployment.cpuLimit | string | `nil` |  |
+| common.deployment.cpuRequest | string | `"100m"` |  |
+| common.deployment.emptyDir[0].containerMount | string | `"/var/lib/docker"` |  |
+| common.deployment.emptyDir[0].name | string | `"docker-data"` |  |
+| common.deployment.memoryLimit | string | `"1Gi"` |  |
+| common.deployment.memoryRequest | string | `"256Mi"` |  |
+| common.deployment.port | int | `6555` |  |
+| common.deployment.strategy.type | string | `"Recreate"` |  |
+| common.hpa.avgCpuUtilization | int | `50` |  |
+| common.hpa.enabled | bool | `false` |  |
+| common.hpa.maxReplicas | int | `2` |  |
+| common.hpa.minReplicas | int | `1` |  |
+| common.image.pullPolicy | string | `"IfNotPresent"` |  |
+| common.image.repository | string | `"ghcr.io/qjoly/spindle"` |  |
+| common.image.repositorySettings.isPrivate | bool | `false` |  |
+| common.image.repositorySettings.secretName | string | `nil` |  |
+| common.image.tag | string | `"v1.16.1-alpha"` |  |
+| common.ingress.enabled | bool | `false` |  |
+| common.ingress.hostName | string | `"spindle.example.com"` |  |
+| common.ingress.ingressClassName | string | `nil` |  |
+| common.ingress.tls.enabled | bool | `true` |  |
+| common.ingress.tls.secretName | string | `""` |  |
+| common.livenessProbe | object | `{}` |  |
+| common.livenessProbeEnabled | bool | `false` |  |
+| common.name | string | `"spindle"` |  |
+| common.persistence.enabled | bool | `true` |  |
+| common.persistence.volumes[0].containerMount | string | `"/var/lib/spindle"` |  |
+| common.persistence.volumes[0].name | string | `"data"` |  |
+| common.persistence.volumes[0].pvcClaim | string | `""` |  |
+| common.persistence.volumes[0].size | string | `"5Gi"` |  |
+| common.persistence.volumes[0].storageClassName | string | `""` |  |
+| common.persistence.volumes[1].containerMount | string | `"/var/log/spindle"` |  |
+| common.persistence.volumes[1].name | string | `"logs"` |  |
+| common.persistence.volumes[1].pvcClaim | string | `""` |  |
+| common.persistence.volumes[1].size | string | `"2Gi"` |  |
+| common.persistence.volumes[1].storageClassName | string | `""` |  |
+| common.readinessProbe.failureThreshold | int | `3` |  |
+| common.readinessProbe.initialDelaySeconds | int | `10` |  |
+| common.readinessProbe.periodSeconds | int | `15` |  |
+| common.readinessProbe.tcpSocket.port | int | `6555` |  |
+| common.readinessProbe.timeoutSeconds | int | `3` |  |
+| common.readinessProbeEnabled | bool | `true` |  |
+| common.service.containerPort | int | `6555` |  |
+| common.service.enabled | bool | `true` |  |
+| common.service.extraLabels | object | `{}` |  |
+| common.service.servicePort | int | `6555` |  |
+| common.service.type | string | `"ClusterIP"` |  |
+| common.startupProbe | object | `{}` |  |
+| common.startupProbeEnabled | bool | `false` |  |
+| common.tests.classicHttp.enabled | bool | `true` |  |
+| common.tests.curlHostHeader.enabled | bool | `true` |  |
+| common.tests.curlHostHeader.path | string | `"/xrpc/sh.tangled.owner"` |  |
+| common.variables.nonSecret.DOCKER_HOST | string | `"tcp://127.0.0.1:2375"` |  |
+| common.variables.nonSecret.SPINDLE_NIXERY_PIPELINES_MAX_CONCURRENT_WORKFLOWS | int | `2` |  |
+| common.variables.nonSecret.SPINDLE_NIXERY_PIPELINES_MAX_JOB_MEMORY_MB | int | `4096` |  |
+| common.variables.nonSecret.SPINDLE_NIXERY_PIPELINES_WORKFLOW_TIMEOUT | string | `"15m"` |  |
+| common.variables.nonSecret.SPINDLE_SERVER_DB_PATH | string | `"/var/lib/spindle/spindle.db"` |  |
+| common.variables.nonSecret.SPINDLE_SERVER_HOSTNAME | string | `"spindle.example.com"` | REQUIRED. Public hostname of this spindle, and it must match the one registered on the appview: the knot signs its requests for that audience. |
+| common.variables.nonSecret.SPINDLE_SERVER_LOG_DIR | string | `"/var/log/spindle"` |  |
+| common.variables.nonSecret.SPINDLE_SERVER_OWNER | string | `"did:plc:000000000000000000000000"` | REQUIRED. ATProto DID of the owner. Resolve yours with `curl "https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle?handle=<handle>"` |
+| common.variables.nonSecret.SPINDLE_SERVER_REPO_DIR | string | `"/var/lib/spindle/repos"` |  |
+| common.variables.nonSecret.SPINDLE_SERVER_TAP_DB_PATH | string | `"/var/lib/spindle/tap.db"` |  |
+| common.variables.secret | object | `{}` |  |
+| define | int | `6555` |  |
+

--- a/charts/spindle/README.md
+++ b/charts/spindle/README.md
@@ -22,7 +22,7 @@ Kubernetes: `>= 1.18`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://rubxkube.github.io/common-charts | common | v0.6.0 |
+| https://rubxkube.github.io/common-charts | common | v0.6.2 |
 
 ## Values
 
@@ -51,7 +51,6 @@ Kubernetes: `>= 1.18`
 | common.deployment.additionalContainers[0].volumeMounts[0].name | string | `"docker-data"` |  |
 | common.deployment.cpuLimit | string | `nil` |  |
 | common.deployment.cpuRequest | string | `"100m"` |  |
-| common.deployment.emptyDir[0].containerMount | string | `"/var/lib/docker"` |  |
 | common.deployment.emptyDir[0].name | string | `"docker-data"` |  |
 | common.deployment.memoryLimit | string | `"1Gi"` |  |
 | common.deployment.memoryRequest | string | `"256Mi"` |  |
@@ -71,8 +70,13 @@ Kubernetes: `>= 1.18`
 | common.ingress.ingressClassName | string | `nil` |  |
 | common.ingress.tls.enabled | bool | `true` |  |
 | common.ingress.tls.secretName | string | `""` |  |
-| common.livenessProbe | object | `{}` |  |
-| common.livenessProbeEnabled | bool | `false` |  |
+| common.livenessProbe.failureThreshold | int | `3` |  |
+| common.livenessProbe.httpGet.path | string | `"/"` |  |
+| common.livenessProbe.httpGet.port | int | `6555` |  |
+| common.livenessProbe.initialDelaySeconds | int | `20` |  |
+| common.livenessProbe.periodSeconds | int | `60` |  |
+| common.livenessProbe.timeoutSeconds | int | `3` |  |
+| common.livenessProbeEnabled | bool | `true` |  |
 | common.name | string | `"spindle"` |  |
 | common.persistence.enabled | bool | `true` |  |
 | common.persistence.volumes[0].containerMount | string | `"/var/lib/spindle"` |  |
@@ -86,9 +90,10 @@ Kubernetes: `>= 1.18`
 | common.persistence.volumes[1].size | string | `"2Gi"` |  |
 | common.persistence.volumes[1].storageClassName | string | `""` |  |
 | common.readinessProbe.failureThreshold | int | `3` |  |
+| common.readinessProbe.httpGet.path | string | `"/"` |  |
+| common.readinessProbe.httpGet.port | int | `6555` |  |
 | common.readinessProbe.initialDelaySeconds | int | `10` |  |
 | common.readinessProbe.periodSeconds | int | `15` |  |
-| common.readinessProbe.tcpSocket.port | int | `6555` |  |
 | common.readinessProbe.timeoutSeconds | int | `3` |  |
 | common.readinessProbeEnabled | bool | `true` |  |
 | common.service.containerPort | int | `6555` |  |

--- a/charts/spindle/values.yaml
+++ b/charts/spindle/values.yaml
@@ -60,9 +60,9 @@ common:
     # docker:dind declares VOLUME /var/lib/docker because overlay2 on overlay2
     # degrades to the vfs storage driver; this keeps the image cache off the
     # container layer. Swap for a PVC if re-pulling on every restart hurts.
+    # No containerMount: the sidecar mounts it, spindle has no use for it.
     emptyDir:
       - name: docker-data
-        containerMount: /var/lib/docker
 
   # container
   image:
@@ -120,10 +120,12 @@ common:
   startupProbe: {}
 
   # readinessProbe
-  # Spindle serves XRPC only, so there is no root path to probe over HTTP.
+  # "/" serves an embedded motd, so it answers without touching the database,
+  # jetstream or the docker daemon.
   readinessProbeEnabled: true
   readinessProbe:
-    tcpSocket:
+    httpGet:
+      path: "/"
       port: *containerPort
     initialDelaySeconds: 10
     periodSeconds: 15
@@ -131,8 +133,15 @@ common:
     timeoutSeconds: 3
 
   # livenessProbe
-  livenessProbeEnabled: false
-  livenessProbe: {}
+  livenessProbeEnabled: true
+  livenessProbe:
+    httpGet:
+      path: "/"
+      port: *containerPort
+    initialDelaySeconds: 20
+    periodSeconds: 60
+    failureThreshold: 3
+    timeoutSeconds: 3
 
   persistence:
     enabled: true

--- a/charts/spindle/values.yaml
+++ b/charts/spindle/values.yaml
@@ -1,0 +1,156 @@
+---
+define: &containerPort 6555
+
+common:
+  name: spindle
+  service:
+    type: ClusterIP
+    enabled: true
+    servicePort: *containerPort
+    containerPort: *containerPort
+    extraLabels: {}
+
+  # deployment
+  deployment:
+    memoryRequest: 256Mi
+    cpuRequest: 100m
+    memoryLimit: 1Gi
+    cpuLimit: null
+    port: *containerPort
+    strategy:
+      type: Recreate
+
+    # Spindle drives a Docker daemon to run pipelines, so one ships alongside it.
+    # Workflow containers are children of this dockerd, so their memory counts
+    # against this container's limit, not spindle's: keep memoryLimit >=
+    # maxConcurrentWorkflows x maxJobMemoryMB below.
+    additionalContainers:
+      - name: dind
+        image: "docker:29.7.2-dind"
+        imagePullPolicy: IfNotPresent
+        # "dockerd" must come first, otherwise dockerd-entrypoint.sh prepends
+        # its own --host=tcp://0.0.0.0:2375 on top of ours: the binds collide
+        # and the daemon exits. Loopback only, since an unauthenticated root
+        # Docker API on the pod IP would be reachable by workflow code.
+        args:
+          - dockerd
+          - --host=unix:///var/run/docker.sock
+          - --host=tcp://127.0.0.1:2375
+          - --tls=false
+        env:
+          - name: DOCKER_TLS_CERTDIR
+            value: ""
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - name: docker-data
+            mountPath: /var/lib/docker
+        resources:
+          requests:
+            memory: 512Mi
+            cpu: 100m
+          limits:
+            memory: 10Gi
+        readinessProbe:
+          exec:
+            command: ["docker", "-H", "tcp://127.0.0.1:2375", "info"]
+          initialDelaySeconds: 10
+          periodSeconds: 15
+
+    # docker:dind declares VOLUME /var/lib/docker because overlay2 on overlay2
+    # degrades to the vfs storage driver; this keeps the image cache off the
+    # container layer. Swap for a PVC if re-pulling on every restart hurts.
+    emptyDir:
+      - name: docker-data
+        containerMount: /var/lib/docker
+
+  # container
+  image:
+    repositorySettings:
+      isPrivate: false
+      secretName: null
+    # Upstream publishes no spindle image, only atcr.io/tangled.org/knot. This
+    # one is built from the monorepo's localinfra/spindle.Dockerfile.
+    repository: ghcr.io/qjoly/spindle
+    tag: v1.16.1-alpha
+    pullPolicy: IfNotPresent
+
+  # ingress
+  ingress:
+    enabled: false
+    hostName: spindle.example.com
+    tls:
+      enabled: true
+      secretName: ""
+    # For Ingress CRD
+    ingressClassName:
+
+  # env variables
+  variables:
+    secret: {}
+    nonSecret:
+      # -- REQUIRED. Public hostname of this spindle, and it must match the one
+      # registered on the appview: the knot signs its requests for that audience.
+      SPINDLE_SERVER_HOSTNAME: spindle.example.com
+      # -- REQUIRED. ATProto DID of the owner. Resolve yours with
+      # `curl "https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle?handle=<handle>"`
+      SPINDLE_SERVER_OWNER: did:plc:000000000000000000000000
+      SPINDLE_SERVER_DB_PATH: /var/lib/spindle/spindle.db
+      SPINDLE_SERVER_TAP_DB_PATH: /var/lib/spindle/tap.db
+      SPINDLE_SERVER_REPO_DIR: /var/lib/spindle/repos
+      # Leave at the default: spindle opens log files without creating their
+      # parent, and only the image entrypoint creates this path.
+      SPINDLE_SERVER_LOG_DIR: /var/log/spindle
+      DOCKER_HOST: tcp://127.0.0.1:2375
+      SPINDLE_NIXERY_PIPELINES_MAX_CONCURRENT_WORKFLOWS: 2
+      SPINDLE_NIXERY_PIPELINES_MAX_JOB_MEMORY_MB: 4096
+      SPINDLE_NIXERY_PIPELINES_WORKFLOW_TIMEOUT: 15m
+
+  # horizontal autoscaler
+  # Spindle keeps its state in SQLite on a ReadWriteOnce volume, so it does not
+  # scale horizontally.
+  hpa:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 2
+    avgCpuUtilization: 50
+
+  # startupProbe
+  startupProbeEnabled: false
+  startupProbe: {}
+
+  # readinessProbe
+  # Spindle serves XRPC only, so there is no root path to probe over HTTP.
+  readinessProbeEnabled: true
+  readinessProbe:
+    tcpSocket:
+      port: *containerPort
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    failureThreshold: 3
+    timeoutSeconds: 3
+
+  # livenessProbe
+  livenessProbeEnabled: false
+  livenessProbe: {}
+
+  persistence:
+    enabled: true
+    volumes:
+      - name: "data"
+        storageClassName: ""  # leave empty if you want to use default
+        size: "5Gi"  # sqlite databases and cloned repositories
+        pvcClaim: ""  # leave empty unless if you want to use an existing PVC
+        containerMount: "/var/lib/spindle"
+      - name: "logs"
+        storageClassName: ""
+        size: "2Gi"  # one file per workflow run, served back to the appview
+        pvcClaim: ""
+        containerMount: "/var/log/spindle"
+
+  tests:
+    classicHttp:  # default helm test method
+      enabled: true
+    curlHostHeader:  # curl using ingress.hostName as Host in header
+      enabled: true
+      path: "/xrpc/sh.tangled.owner"


### PR DESCRIPTION
## Chart Addition Pull Request

Name: spindle
version: 0.1.0

**Additional Information**

[Spindle](https://docs.tangled.org/spindles) is the CI runner of Tangled. This chart deploys one instance.

Spindle drives a Docker daemon to run pipelines, so the chart ships a `dind` sidecar and points `DOCKER_HOST` at it. Two things worth a look:

- The sidecar is `privileged`. That is inherent to Docker-in-Docker, and the daemon binds **loopback only** — an unauthenticated root Docker API on the pod IP would otherwise be reachable by workflow code.
- `SPINDLE_SERVER_HOSTNAME` and `SPINDLE_SERVER_OWNER` are required by spindle and cannot have working defaults. They are the only two values carrying a helm-docs `# --` description, so they show up in the README table — no other chart here uses that format, so revert it if you would rather stay uniform.

The image is `ghcr.io/qjoly/spindle`: upstream publishes no spindle image (only `atcr.io/tangled.org/knot`), so it is built from the monorepo's `localinfra/spindle.Dockerfile`. `linux/amd64` and `linux/arm64`.

Depends on `common v0.6.2`, which is what makes the volume scoping below possible.

**Checklist**

Please review and check the following before submitting this pull request:

- [x] I have tested the chart locally and it works as expected.
- [x] I have considered security best practices while creating the chart.

Installed on kind (arm64, podman) exactly as `deploy_modified_charts.sh` does it — `helm install spindle . --wait --timeout 300s` in the default namespace:

- Ready in **21s** of the 300s budget, both containers `ready=true`, 0 restarts.
- Volumes land only where they belong: `dind` gets `/var/lib/docker`, `spindle` gets `/var/lib/spindle` + `/var/log/spindle` and nothing else.
- `spindle` answers XRPC: `GET /xrpc/sh.tangled.owner` → `{"owner":"did:plc:0000…"}`.
- `dind` answers on loopback: `docker version` → `29.7.2`.
- Both PVCs bind on the `standard` StorageClass.
- `helm test` → both pods `Succeeded`.
- `yamllint charts/spindle/` clean.

**Version Information**

- [ ] I have updated the min version in the Chart.yaml file if necessary.
- [x] I want a new patch version for this chart (I don't need to update the min version in the Chart.yaml file).

**Screenshots or Examples (if applicable)**

```bash
helm install spindle rubxkube/spindle \
  --set common.variables.nonSecret.SPINDLE_SERVER_HOSTNAME=spindle.example.com \
  --set common.variables.nonSecret.SPINDLE_SERVER_OWNER=did:plc:xxxxxxxxxxxxxxxxxxxxxxxx \
  --set common.ingress.enabled=true \
  --set common.ingress.hostName=spindle.example.com
```

Then register the spindle in the Tangled UI, and point a repository at it by setting `spindle` in its settings.

**One thing you may want to fix separately**

`common`'s `curlHostHeader` test passes its header with literal double quotes:

```
args: ['…', '-H', '"Host:{{ .Values.ingress.hostName }}:{{ .Values.service.servicePort }}"']
```

The quotes end up in the header name, so the server rejects the request. Reproduced against this chart, same URL, same pod:

```
curl … -H '"Host:spindle.example.com:6555"'   → HTTP 400
curl … -H 'Host:spindle.example.com:6555'     → HTTP 200
```

It is invisible today because the test runs `curl -v` without `-f`, so the pod exits 0 on a 400 and `helm test` passes. That affects every chart with `curlHostHeader.enabled: true`, not just this one — happy to send a PR against common-charts if you want it.
