### PR TITLE
ci(release): register valkey helm repo to unblock chart-releaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,7 @@ jobs:
           helm repo add common https://rubxkube.github.io/common-charts
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo add meilisearch https://meilisearch.github.io/meilisearch-kubernetes
+          helm repo add valkey https://valkey.io/valkey-helm
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
## What

Add `helm repo add valkey https://valkey.io/valkey-helm` to the **Helm common repo** step of `.github/workflows/release.yml`, next to the existing `common`, `bitnami` and `meilisearch` repos.

## Why

The `Release Charts` workflow has been failing at the **Run chart-releaser** step:

```
Packaging chart 'charts/searxng'...
Error: no repository definition for https://valkey.io/valkey-helm
```

The `searxng` chart (added in #424) declares a dependency on `valkey`:

```yaml
# charts/searxng/Chart.yaml
dependencies:
  - name: valkey
    repository: https://valkey.io/valkey-helm
    version: 0.11.0
    condition: valkey.enabled
```

chart-releaser runs `helm dependency build`, which resolves each dependency **by URL** against the registered Helm repos. The `valkey` repo was never registered in the workflow, so packaging `searxng` fails.

Because chart-releaser processes charts serially and exits on the first error, **nothing gets published to the Helm index** — not just `searxng`, but every pending chart, including `languagetool` (#428) whose `.tgz` was packaged successfully before the failure.

## Verification

- The referenced repo is valid: `https://valkey.io/valkey-helm/index.yaml` returns HTTP 200 and serves `valkey 0.11.0` (app 9.1.1), matching the version pinned in `searxng`'s `Chart.lock`.
- This is the same pattern already used for `bitnami` and `meilisearch` external dependencies.

## Follow-up

Once merged, a push to `main` (or a manual re-run of the workflow) will re-run the release and publish the currently-pending charts (`searxng` and `languagetool`) to the index.