### PR TITLE
ci(release): skip existing releases in chart-releaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,7 @@ jobs:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           charts_dir: charts
+          skip_existing: true
 
       - name: Modifying the readme on main
         continue-on-error: true


### PR DESCRIPTION
## What

Add `skip_existing: true` to the `Run chart-releaser` step in `.github/workflows/release.yml`.

## Why

After [#429](https://github.com/RubxKube/charts/pull/429) fixed the `valkey` repo definition, the release run got past packaging (`searxng-0.1.0` and `languagetool-0.1.0` are now packaged successfully) but failed in the **upload** phase:

```
Error: error creating GitHub release audiobookshelf-0.1.2:
POST .../releases: 422 Validation Failed [tag_name: already_exists]
```

`chart-releaser` packages every chart under `charts/` and then tries to create a GitHub release for each one. The `increase-version` job only bumps charts changed in the merge commit, so unchanged charts keep their current version. Without `skip_existing`, `chart-releaser` exits `1` on the first tag that already exists (`audiobookshelf-0.1.2`), which aborts the whole publish step before the genuinely new charts are uploaded to the index.

This was a latent bug: until now the packaging step died earlier (on the `valkey` dependency), so the upload phase was never reached.

## Fix

`skip_existing: true` makes `chart-releaser` skip already-published releases and only create the missing ones — here, `searxng-0.1.0` and `languagetool-0.1.0`. It also keeps any future single-chart merge from re-breaking on pre-existing tags.

## Follow-up

Once merged, a push to `main` (or a re-run of `Release Charts`) will publish the pending charts into the Helm index, unblocking downstream consumers that pin `languagetool 0.1.0`.
