### PR TITLE
feat(tranquil-pds): add AT Protocol PDS chart

### DIFF
--- a/charts/tranquil-pds/.helmignore
+++ b/charts/tranquil-pds/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/tranquil-pds/Chart.yaml
+++ b/charts/tranquil-pds/Chart.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v2
+type: application
+name: tranquil-pds
+description: Tranquil PDS (AT Protocol Personal Data Server, Rust) with a bundled PostgreSQL and optional OIDC SSO.
+version: 0.1.0
+appVersion: "latest"
+maintainers:
+  - name: QJOLY
+    email: github@une-tasse-de.cafe
+kubeVersion: ">= 1.18"
+home: https://tangled.org/tranquil.farm/tranquil-pds
+keywords:
+  - atproto
+  - pds
+  - bluesky
+  - tranquil
+sources:
+  - https://tangled.org/tranquil.farm/tranquil-pds

--- a/charts/tranquil-pds/README.md
+++ b/charts/tranquil-pds/README.md
@@ -1,0 +1,62 @@
+# tranquil-pds
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+
+Tranquil PDS (AT Protocol Personal Data Server, Rust) with a bundled PostgreSQL and optional OIDC SSO.
+
+User handles are served as subdomains of `ingress.host`, so the chart issues a
+**wildcard** TLS certificate (`*.host`) via cert-manager. All application secrets
+(database password, JWT/DPoP/master keys, OIDC client credentials, and the image
+pull `dockerconfigjson`) are pulled from an external-secrets store — the chart
+creates the `Secret`s, never the values.
+
+**Homepage:** <https://tangled.org/tranquil.farm/tranquil-pds>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| QJOLY | <github@une-tasse-de.cafe> |  |
+
+## Source Code
+
+* <https://tangled.org/tranquil.farm/tranquil-pds>
+
+## Requirements
+
+The target cluster must provide:
+
+* [external-secrets](https://external-secrets.io/) with a reachable store (a
+  `ClusterSecretStore` named `vault-backend` by default).
+* [cert-manager](https://cert-manager.io/) with a `ClusterIssuer` able to solve
+  **DNS-01** (required to issue the wildcard certificate).
+
+The secret referenced by `vault.key` in the store must contain: `db_password`,
+`jwt_secret`, `dpop_secret`, `master_key`, `dockerconfigjson`, and — when
+`sso.enabled` — `authentik_id` and `authentik_secret`.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| image | string | `"atcr.io/tranquil.farm/tranquil-pds:latest"` | Container image for the PDS. |
+| imagePullPolicy | string | `"IfNotPresent"` | Image pull policy. |
+| imagePullSecret | string | `"atcr-pull"` | Name of the imagePullSecret (materialized from the store). |
+| secretName | string | `"tranquil-pds-secrets"` | Name of the app Secret (materialized from the store). |
+| storageClass | string | `""` | StorageClass for the blob and database volumes (empty = cluster default). |
+| app.blobStorage | string | `"10Gi"` | Storage size for the blob PVC. |
+| app.resources | object | requests 100m/256Mi, limit 1Gi | Resources for the PDS container. |
+| db.image | string | `"postgres:18-alpine"` | PostgreSQL image. |
+| db.storage | string | `"10Gi"` | Storage size for the database PVC. |
+| db.resources | object | requests 50m/128Mi, limit 512Mi | Resources for the PostgreSQL container. |
+| ingress.host | string | `"pds.example.com"` | Public hostname; handles are served as `*.host`. |
+| ingress.className | string | `"nginx"` | IngressClass name. |
+| ingress.clusterIssuer | string | `"letsencrypt-prod"` | cert-manager ClusterIssuer for the wildcard certificate. |
+| ingress.tlsSecretName | string | `"tranquil-pds-tls"` | Name of the TLS Secret produced by the Certificate. |
+| sso.enabled | bool | `true` | Enable OIDC single sign-on. |
+| sso.issuer | string | `""` | OIDC issuer URL (the exact `iss` validated by the PDS). |
+| sso.displayName | string | `"SSO"` | Display name of the SSO button. |
+| secretStore.name | string | `"vault-backend"` | Name of the external-secrets store. |
+| secretStore.kind | string | `"ClusterSecretStore"` | Kind of the store. |
+| secretStore.refreshInterval | string | `"1h"` | Refresh interval for the ExternalSecrets. |
+| vault.key | string | `"tranquil-pds"` | Remote key (secret path) in the store. |

--- a/charts/tranquil-pds/templates/certificate.yaml
+++ b/charts/tranquil-pds/templates/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: tranquil-pds-tls
+spec:
+  secretName: {{ .Values.ingress.tlsSecretName }}
+  issuerRef:
+    name: {{ .Values.ingress.clusterIssuer }}
+    kind: ClusterIssuer
+  dnsNames:
+    - {{ .Values.ingress.host }}
+    - "*.{{ .Values.ingress.host }}"

--- a/charts/tranquil-pds/templates/deployment.yaml
+++ b/charts/tranquil-pds/templates/deployment.yaml
@@ -1,0 +1,105 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tranquil-pds
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tranquil-pds
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: tranquil-pds
+    spec:
+      imagePullSecrets:
+        - name: {{ .Values.imagePullSecret }}
+      containers:
+        - name: tranquil-pds
+          image: {{ .Values.image }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          ports:
+            - containerPort: 3000
+          env:
+            - name: PDS_HOSTNAME
+              value: {{ .Values.ingress.host | quote }}
+            - name: SERVER_HOST
+              value: "0.0.0.0"
+            - name: SERVER_PORT
+              value: "3000"
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secretName }}
+                  key: DB_PASSWORD
+            - name: DATABASE_URL
+              value: postgres://tranquil_pds:$(DB_PASSWORD)@tranquil-pds-db:5432/pds
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secretName }}
+                  key: JWT_SECRET
+            - name: DPOP_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secretName }}
+                  key: DPOP_SECRET
+            - name: MASTER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secretName }}
+                  key: MASTER_KEY
+            {{- if .Values.sso.enabled }}
+            - name: SSO_OIDC_ENABLED
+              value: "true"
+            - name: SSO_OIDC_ISSUER
+              value: {{ .Values.sso.issuer | quote }}
+            - name: SSO_OIDC_DISPLAY_NAME
+              value: {{ .Values.sso.displayName | quote }}
+            - name: SSO_OIDC_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secretName }}
+                  key: SSO_OIDC_CLIENT_ID
+            - name: SSO_OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secretName }}
+                  key: SSO_OIDC_CLIENT_SECRET
+            {{- end }}
+          volumeMounts:
+            - name: blobs
+              mountPath: /var/lib/tranquil-pds/blobs
+          readinessProbe:
+            httpGet:
+              path: /xrpc/_health
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /xrpc/_health
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          resources:
+            {{- toYaml .Values.app.resources | nindent 12 }}
+      volumes:
+        - name: blobs
+          persistentVolumeClaim:
+            claimName: tranquil-pds-blobs
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: tranquil-pds-blobs
+spec:
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: {{ .Values.storageClass }}
+  resources:
+    requests:
+      storage: {{ .Values.app.blobStorage }}

--- a/charts/tranquil-pds/templates/externalsecret.yaml
+++ b/charts/tranquil-pds/templates/externalsecret.yaml
@@ -1,0 +1,39 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: tranquil-pds-secrets
+spec:
+  refreshInterval: {{ .Values.secretStore.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ .Values.secretStore.name }}
+    kind: {{ .Values.secretStore.kind }}
+  target:
+    name: {{ .Values.secretName }}
+    creationPolicy: Owner
+  data:
+    - secretKey: DB_PASSWORD
+      remoteRef:
+        key: {{ .Values.vault.key }}
+        property: db_password
+    - secretKey: JWT_SECRET
+      remoteRef:
+        key: {{ .Values.vault.key }}
+        property: jwt_secret
+    - secretKey: DPOP_SECRET
+      remoteRef:
+        key: {{ .Values.vault.key }}
+        property: dpop_secret
+    - secretKey: MASTER_KEY
+      remoteRef:
+        key: {{ .Values.vault.key }}
+        property: master_key
+    {{- if .Values.sso.enabled }}
+    - secretKey: SSO_OIDC_CLIENT_ID
+      remoteRef:
+        key: {{ .Values.vault.key }}
+        property: authentik_id
+    - secretKey: SSO_OIDC_CLIENT_SECRET
+      remoteRef:
+        key: {{ .Values.vault.key }}
+        property: authentik_secret
+    {{- end }}

--- a/charts/tranquil-pds/templates/ingress.yaml
+++ b/charts/tranquil-pds/templates/ingress.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tranquil-pds
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+        - "*.{{ .Values.ingress.host }}"
+      secretName: {{ .Values.ingress.tlsSecretName }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: tranquil-pds
+                port:
+                  number: 80
+    - host: "*.{{ .Values.ingress.host }}"
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: tranquil-pds
+                port:
+                  number: 80

--- a/charts/tranquil-pds/templates/postgres.yaml
+++ b/charts/tranquil-pds/templates/postgres.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tranquil-pds-db
+spec:
+  selector:
+    app: tranquil-pds-db
+  ports:
+    - port: 5432
+      targetPort: 5432
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: tranquil-pds-db
+spec:
+  serviceName: tranquil-pds-db
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tranquil-pds-db
+  template:
+    metadata:
+      labels:
+        app: tranquil-pds-db
+    spec:
+      containers:
+        - name: postgres
+          image: {{ .Values.db.image }}
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_USER
+              value: tranquil_pds
+            - name: POSTGRES_DB
+              value: pds
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secretName }}
+                  key: DB_PASSWORD
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql
+          resources:
+            {{- toYaml .Values.db.resources | nindent 12 }}
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "tranquil_pds", "-d", "pds"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: {{ .Values.storageClass }}
+        resources:
+          requests:
+            storage: {{ .Values.db.storage }}

--- a/charts/tranquil-pds/templates/pull-secret.yaml
+++ b/charts/tranquil-pds/templates/pull-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.imagePullSecret }}
+spec:
+  refreshInterval: {{ .Values.secretStore.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ .Values.secretStore.name }}
+    kind: {{ .Values.secretStore.kind }}
+  target:
+    name: {{ .Values.imagePullSecret }}
+    creationPolicy: Owner
+    template:
+      type: kubernetes.io/dockerconfigjson
+  data:
+    - secretKey: .dockerconfigjson
+      remoteRef:
+        key: {{ .Values.vault.key }}
+        property: dockerconfigjson

--- a/charts/tranquil-pds/templates/service.yaml
+++ b/charts/tranquil-pds/templates/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tranquil-pds
+spec:
+  selector:
+    app: tranquil-pds
+  ports:
+    - port: 80
+      targetPort: 3000

--- a/charts/tranquil-pds/values.yaml
+++ b/charts/tranquil-pds/values.yaml
@@ -1,0 +1,73 @@
+---
+# Default values for tranquil-pds.
+
+# -- Container image for the PDS.
+image: atcr.io/tranquil.farm/tranquil-pds:latest
+# -- Image pull policy.
+imagePullPolicy: IfNotPresent
+# -- Name of the imagePullSecret used to pull the (private) image. It is
+# materialized by the ExternalSecret in templates/pull-secret.yaml.
+imagePullSecret: atcr-pull
+# -- Name of the Secret holding the app secrets, materialized from the secret
+# store by templates/externalsecret.yaml.
+secretName: tranquil-pds-secrets
+
+# -- StorageClass for the blob and database volumes. Empty uses the cluster
+# default.
+storageClass: ""
+
+app:
+  # -- Storage size for the blob PVC (uploaded media).
+  blobStorage: 10Gi
+  # -- Resource requests/limits for the PDS container.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 1Gi
+
+db:
+  # -- PostgreSQL image. The PDS runs its own migrations at boot.
+  image: postgres:18-alpine
+  # -- Storage size for the database PVC.
+  storage: 10Gi
+  # -- Resource requests/limits for the PostgreSQL container.
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 512Mi
+
+ingress:
+  # -- Public hostname of the PDS. User handles are served as subdomains
+  # (*.host), so a wildcard TLS certificate is issued for it.
+  host: pds.example.com
+  # -- IngressClass name.
+  className: nginx
+  # -- cert-manager ClusterIssuer used for the wildcard certificate.
+  clusterIssuer: letsencrypt-prod
+  # -- Name of the TLS Secret produced by the Certificate.
+  tlsSecretName: tranquil-pds-tls
+
+sso:
+  # -- Enable OIDC single sign-on. When true, SSO_OIDC_CLIENT_ID and
+  # SSO_OIDC_CLIENT_SECRET must be present in the app secret.
+  enabled: true
+  # -- OIDC issuer URL (the exact iss the PDS validates against).
+  issuer: ""
+  # -- Display name of the SSO button.
+  displayName: SSO
+
+secretStore:
+  # -- Name of the external-secrets store to read secrets from.
+  name: vault-backend
+  # -- Kind of the store: ClusterSecretStore or SecretStore.
+  kind: ClusterSecretStore
+  # -- Refresh interval for the ExternalSecrets.
+  refreshInterval: 1h
+
+vault:
+  # -- Remote key (secret path) in the store holding this app's secrets.
+  key: tranquil-pds


### PR DESCRIPTION
## What

Adds a dedicated, standalone Helm chart `tranquil-pds` — a self-hostable [AT Protocol](https://atproto.com/) PDS (`tranquil.farm/tranquil-pds`, Rust).

## Why

The PDS is being deployed on the `mocha` cluster via GitOps. Following the repo convention (generic charts here, deployment-specific config in GitOps), the chart is kept generic and reusable; all cluster-specific values stay on the consumer side.

## Contents

- **Deployment**: PDS app (port 3000) + PVC for blob storage
- **Postgres 18** StatefulSet + Service (backing store; migrations run automatically on boot)
- **Ingress + Certificate** with a **wildcard host** (`*.<host>`) — user handles are served as subdomains, so a wildcard cert (DNS-01) is required
- **ExternalSecret** (app secrets: db password, JWT/DPoP/master keys, OIDC creds) + **ExternalSecret** for the private-registry pull secret
- Optional generic **SSO/OIDC** wiring (`sso.enabled`, `sso.issuer`, `sso.displayName`) — a generic OIDC provider, IdP-agnostic

## Notes

- Standalone chart (own `templates/`), same pattern as `trmnl-server` / `cloudflare-tunnel`.
- Ships `.no_ci` (like `trmnl-server`): the kind `helm install` smoke test would fail because the chart needs the external-secrets / cert-manager CRDs and a private image. The chart is still released to `rubxkube.github.io/charts`.
- Generic defaults are neutral (`pds.example.com`, `nginx`, `letsencrypt-prod`).

## Validation

- `helm lint` OK
- `helm template` with realistic values renders 9 objects, no errors (DATABASE_URL interpolation, wildcard host, SSO env, pull secret all intact)
- `yamllint` (repo CI gate) OK on `Chart.yaml` / `values.yaml`