### PR TITLE
feat(tranquil-pds): add crawlers passthrough to override relay list

### DIFF
--- a/charts/tranquil-pds/Chart.yaml
+++ b/charts/tranquil-pds/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 type: application
 name: tranquil-pds
 description: Tranquil PDS (AT Protocol Personal Data Server, Rust) with a bundled PostgreSQL and optional OIDC SSO.
-version: 0.1.0
+version: 0.2.0
 appVersion: "latest"
 maintainers:
   - name: QJOLY

--- a/charts/tranquil-pds/templates/deployment.yaml
+++ b/charts/tranquil-pds/templates/deployment.yaml
@@ -71,6 +71,10 @@ spec:
                   name: {{ .Values.secretName }}
                   key: SSO_OIDC_CLIENT_SECRET
             {{- end }}
+            {{- if .Values.crawlers }}
+            - name: CRAWLERS
+              value: {{ join "," .Values.crawlers | quote }}
+            {{- end }}
           volumeMounts:
             - name: blobs
               mountPath: /var/lib/tranquil-pds/blobs

--- a/charts/tranquil-pds/values.yaml
+++ b/charts/tranquil-pds/values.yaml
@@ -16,6 +16,11 @@ secretName: tranquil-pds-secrets
 # default.
 storageClass: ""
 
+# -- Relay / crawler URLs the PDS notifies (requestCrawl) so the network
+# federates the repo. Empty (default) keeps the PDS built-in relay list; set it
+# to override — e.g. to drop an unreachable relay.
+crawlers: []
+
 app:
   # -- Storage size for the blob PVC (uploaded media).
   blobStorage: 10Gi


### PR DESCRIPTION
## What

Add an optional `crawlers` value to the `tranquil-pds` chart (list of relay / crawler URLs). When non-empty, the chart renders the `CRAWLERS` env var (comma-joined) on the PDS container.

## Why

The PDS ships a built-in default relay list that currently includes an unreachable relay (`relay.fire.hose.cam`), which spams `Failed to notify crawler` warnings on every `requestCrawl`. This knob lets a deployment override the list (deployment-specific config stays in GitOps, per convention) — e.g. to drop the dead relay while keeping `bsky.network` and the other reachable ones.

## Behavior

- `crawlers: []` (default) → **no** `CRAWLERS` env is rendered → the PDS keeps its built-in list. Existing deployments are unaffected.
- `crawlers: [ ... ]` → `CRAWLERS="url1,url2,..."` (the exact comma-separated format the PDS parses via `split_comma_list`).

## Validation

- `helm lint` OK.
- `helm template` with a list → `CRAWLERS` env rendered comma-joined; without → no `CRAWLERS` env.
- `yamllint` (repo config) OK on `values.yaml` / `Chart.yaml`.
- Chart bumped to `0.2.0`.

The GitOps consumer (`mocha/apps/tranquil-pds`) will be updated to `targetRevision: 0.2.0` and set the actual relay list in a follow-up PR once this is released.